### PR TITLE
Fix missing '

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Vue.use(VueI18nDirectives);
 
 <template lang="pug">
   <h1 v-t="'user.name'"></h1>      <!-- normal translation -->
-  <input v-tp="user.password'"/>   <!-- placeholder translation -->
+  <input v-tp="'user.password'"/>   <!-- placeholder translation -->
 
   <p v-tc="'user.jobTitle'"></p>   <!-- capitalize translation -->
   <p v-tu="'user.role'"></p>       <!-- uppercase translation -->


### PR DESCRIPTION
The example code from the readme throws an error because a `'` is missing in the `input v-tp` example.